### PR TITLE
Add ModernBERT backend and integrate with UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,21 @@ Clone the repo and install dependencies:
 git clone https://github.com/Reachariramanan/BERTViz.git
 cd BERTViz
 pip install -r requirements.txt
+npm install
 ````
 
 ---
 
 ## 🖥️ Run the App
 
+Start the Python backend and the Next.js frontend:
+
 ```bash
-streamlit run app.py
+uvicorn app:app --reload
+npm run dev
 ```
 
-This will open the BERTviz Explorer in your browser. Input any sentence and click **Visualize**.
+The backend exposes an `/analyze` endpoint used by the UI to fetch tokens and attention weights.
 
 ---
 
@@ -62,11 +66,10 @@ Layer-wise attention heatmaps showing how each word attends to others across the
 
 ```
 BERTViz/
-├── app.py
+├── app.py             # FastAPI server serving attentions
+├── src/               # Next.js frontend
 ├── readme/
 │   └── image.png
-├── components/
-├── models/
 ├── requirements.txt
 └── README.md
 ```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from transformers import AutoTokenizer, AutoModel
+import torch
+
+app = FastAPI()
+
+MODEL_NAME = "answerdotai/ModernBERT-base"
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+model = AutoModel.from_pretrained(MODEL_NAME, output_attentions=True)
+model.eval()
+
+class AnalyzeRequest(BaseModel):
+    sentence: str
+
+class AnalyzeResponse(BaseModel):
+    tokens: list[str]
+    attention: list[list[list[float]]]
+
+@app.post("/analyze", response_model=AnalyzeResponse)
+def analyze(req: AnalyzeRequest):
+    inputs = tokenizer(req.sentence, return_tensors="pt")
+    with torch.no_grad():
+        outputs = model(**inputs)
+    attentions = [att[0].mean(dim=0).tolist() for att in outputs.attentions]
+    tokens = tokenizer.convert_ids_to_tokens(inputs["input_ids"][0])
+    return {"tokens": tokens, "attention": attentions}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+transformers
+torch


### PR DESCRIPTION
## Summary
- add FastAPI backend in `app.py` loading `answerdotai/ModernBERT-base`
- expose `/analyze` endpoint used by frontend
- connect frontend to backend and allow dynamic number of layers
- update README with new instructions
- add Python requirements

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run typecheck` *(fails to run due to missing modules)*
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685df1e9d18c832c83f3d9eae64e1b72